### PR TITLE
Exposing the networking lib

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,15 @@
 const ContentReaderWriter = require('./contentReaderWriter');
-const helpers = ('./helpers.js');
+const helpers = require('./helpers.js');
 const Curriculum = require('./curriculum');
 const Topic = require('./topic');
 const Course = require('./course');
 const Standard = require('./standard');
 const Workout = require('./workout');
 const Insight = require('./insight');
+const networking = require('./networking/github');
 
 module.exports = {
+  networking,
   ContentReaderWriter,
   Curriculum,
   Topic,


### PR DESCRIPTION
Being able to reference the Github class is paramount in using this library in other projects.

(Also helpers.js was being concatenated as a series of 1-character strings. Fixed.)