### PR TITLE
Fixed obscure h3 bug

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -5,6 +5,8 @@ const { removeEmptyObjectProperties, getMarkdownLink } = require('./helpers');
 // Not meant to be the main parser, just meant to provide an abstraction for dealing with lots of curriculum.
 
 const extractSection = ({ rawText, sectionTitle }) => {
+  sectionTitle = `\n${sectionTitle}`;
+  
   let startIndex = rawText.indexOf(sectionTitle) + sectionTitle.length + 1;
 
   // Insight does not have Quiz Question!


### PR DESCRIPTION
[This file](https://github.com/enkidevs/curriculum/blob/master/git/essentials/getting-started/some-common-terminology.md) uses the special term `Revision` in the body of its content as an H3 
`### Revision`

To fix, I altered the `extractSection` function to anticipate a new-line character before the `sectionTitle` argument.