### PR TITLE
[Aspects Script] Second Iteration

### DIFF
--- a/scripts/aspects.js
+++ b/scripts/aspects.js
@@ -1,0 +1,34 @@
+'use strict'
+// utility for reading in the entire curriculum from a file path
+const fs = require('fs')
+const Insight = require('../lib/insight')
+const vfile = require('to-vfile')
+
+// My local path
+// Used find command from unix to get slugs for all insights
+// Load them into the pathList array
+// Also perform filtering to exclude README.ME files and LICENSE.md
+// However I don't know how to exclude exercises as well
+const localPath = '../../curriculum2/pathFile.txt'
+const aspects = ['new', 'workout', 'deep', 'introduction', 'obscura']
+let path = []
+let pathsList = []
+path = fs.readFileSync(localPath).toString('utf-8')
+pathsList = path.split('\n')
+pathsList
+  .filter(path => {
+    return (!path.includes('README.md') && !path.includes('LICENSE.md') && !path.includes('practice'))
+  }).forEach(insightPath => {
+    if (fs.existsSync(insightPath)) {
+      const insightFile = vfile.readSync(insightPath, 'utf-8')
+      const insight = new Insight({ body: insightFile.contents, path: insightPath })
+      if (insight.metadata.tags) {
+        insight.metadata.tags.forEach(tag => {
+          if (aspects.includes(tag)) {
+            console.log(insightPath)
+            console.log(tag)
+          }
+        })
+      }
+    }
+  })


### PR DESCRIPTION
## Done:

- [x] Find insights' slugs with `find` unix command and save them in a separate txt file.
- [x] The script loads all insights' slugs in a `String` array. 
- [x] Creates a new instance for all insights and checks whether they have tags specified.
- [x] If tags are specified the script treats these insights separately. 

## To Do:

Not sure if the current state of insight object can hold aspects in metadata. Might need a couple of changes in the insight.js file as well. 
- [ ] Move all **aspects** listed in **tags**.