### PR TITLE
Start parsing SVGs from root node instead of content node

### DIFF
--- a/lib/insight.js
+++ b/lib/insight.js
@@ -66,7 +66,8 @@ module.exports = class Insight extends Content {
       const contentNode = find(ast, { type: 'section', name: 'Content' })
       this.content = compileAstNodeToInsight(contentNode)
 
-      this.images = extractSvgsFromAstNode(contentNode)
+      this.images = extractSvgsFromAstNode(ast)
+      console.log(this.images)
 
       const practiceNode = find(ast, { type: 'section', name: 'Practice' })
       this.practiceQuestion = extractQuestionFromAstNode(practiceNode)
@@ -215,12 +216,12 @@ function extractExercise ({ link, linkType, answer }, node) {
   }
 }
 
-function extractSvgsFromAstNode (contentNode) {
-  if (!contentNode) {
+function extractSvgsFromAstNode (ast) {
+  if (!ast) {
     return
   }
   const images = []
-  visit(contentNode, { type: 'image' }, node => images.push(node))
+  visit(ast, { type: 'image' }, node => images.push(node))
 
   return images.map(svg => ({
     slug: svg.alt || svg.title,

--- a/lib/insight.js
+++ b/lib/insight.js
@@ -67,7 +67,6 @@ module.exports = class Insight extends Content {
       this.content = compileAstNodeToInsight(contentNode)
 
       this.images = extractSvgsFromAstNode(ast)
-      console.log(this.images)
 
       const practiceNode = find(ast, { type: 'section', name: 'Practice' })
       this.practiceQuestion = extractQuestionFromAstNode(practiceNode)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamenki/curriculum-tools",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamenki/curriculum-tools",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Scripts and parsers for organizing, analysing, and reformatting curriculum programmatically. GPL3",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`curriculum-tools` version is monoenki has to be updated after merging this in.